### PR TITLE
Custom ifp animations 

### DIFF
--- a/Client/game_sa/CAnimBlendHierarchySA.h
+++ b/Client/game_sa/CAnimBlendHierarchySA.h
@@ -34,6 +34,7 @@ public:
     BYTE                                            pad;
     int                                             iAnimBlockID;
     float                                           fTotalTime;
+    DWORD *                                         pLinkPtr;
     //class CLink<class CAnimBlendHierarchy *> *      pLinkPtr;
 };
 

--- a/Client/game_sa/CAnimBlockSA.h
+++ b/Client/game_sa/CAnimBlockSA.h
@@ -27,7 +27,9 @@ public:
     bool                bLoaded;    // ?
     BYTE                pad [ 1 ];
     unsigned short      usRefs;
-    BYTE                pad2 [ 12 ];
+    int                 idOffset;
+    size_t              nAnimations;
+    DWORD               dwAssocGroup;
 };
 
 class CAnimBlockSA : public CAnimBlock

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -594,11 +594,12 @@ public:
     void                                      RemoveIFPPointerFromMap         ( const SString & strBlockName );
     CClientIFP *                              GetIFPPointerFromMap            ( const SString & strBlockName );
 
-    void                                      InsertPedPointerToMap ( CClientPed * pPed );
-    void                                      RemovePedPointerFromMap ( CClientPed * pPed );
-    CClientPed *                              GetClientPedByClump ( const RpClump & Clump );
-  
+    void                                      InsertPedPointerToMap           ( CClientPed * pPed );
+    void                                      RemovePedPointerFromMap         ( CClientPed * pPed );
+    CClientPed *                              GetClientPedByClump             ( const RpClump & Clump );
 
+    void                                      onClientIFPUnload               ( const CClientIFP & IFP );
+ 
 private:
     eStatus                                   m_Status;
     eServerType                               m_ServerType;

--- a/Client/mods/deathmatch/logic/CClientIFP.cpp
+++ b/Client/mods/deathmatch/logic/CClientIFP.cpp
@@ -50,7 +50,12 @@ void CClientIFP::UnloadIFP ( void )
     { 
         printf ("CClientIFP::UnloadIFP ( ) called!\n");
     
-        
+        // first remove IFP from map, so we can indicate that it does not exist
+        g_pClientGame->RemoveIFPPointerFromMap ( m_strBlockName );
+
+        // remove IFP animations from replaced animations of peds/players
+        g_pClientGame->onClientIFPUnload ( *this );
+
         for ( size_t i = 0; i < m_Animations.size(); i++ )
         {
             IFP_Animation * ifpAnimation = &m_Animations[i];
@@ -80,9 +85,7 @@ void CClientIFP::UnloadIFP ( void )
             delete ifpAnimation->pSequencesMemory;  
         }
 
-        g_pClientGame->RemoveIFPPointerFromMap ( m_strBlockName );
-
-        printf ("IFP unloaded sucessfully, removed from map as well.\n");  
+        printf ("IFP unloaded sucessfully with block name '%s'\n", m_strBlockName.c_str());  
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -24,6 +24,8 @@ class CClientPed;
 
 #include <multiplayer/CMultiplayer.h>
 #include "CClientPad.h"
+#include <../game_sa/CAnimBlendHierarchySA.h>
+#include <memory>
 
 class CClientCamera;
 class CClientManager;
@@ -116,6 +118,14 @@ struct SRestoreWeaponItem
     eWeaponType         eWeaponID;
 };
 
+class CClientIFP;
+
+struct SReplacedAnimation
+{
+    CClientIFP *                     pIFP;
+    CAnimBlendHierarchySAInterface * pAnimationHierarchy;
+};
+
 class CClientObject;
 
 // To hide the ugly "pointer truncation from DWORD* to unsigned long warning
@@ -124,6 +134,7 @@ class CClientObject;
 class CClientPed : public CClientStreamElement, public CAntiCheatModule
 {
     DECLARE_CLASS( CClientPed, CClientStreamElement )
+    typedef std::map < CAnimBlendHierarchySAInterface *, SReplacedAnimation > ReplacedAnim_type;
     friend class CClientCamera;
     friend class CClientPlayer;
     friend class CClientVehicle;
@@ -464,6 +475,12 @@ public:
     const SString  &            GetNextAnimationCustomBlockName ( void ) { return m_strCustomIFPBlockName; }
     const SString  &            GetNextAnimationCustomName      ( void ) { return m_strCustomIFPAnimationName; }
 
+    void                        ReplaceAnimation        ( CAnimBlendHierarchy * pInternalAnimHierarchy, CClientIFP * pIFP, CAnimBlendHierarchySAInterface * pCustomAnimHierarchy );
+    void                        RestoreAnimation        ( CAnimBlendHierarchy * pInternalAnimHierarchy );
+    void                        RestoreAnimations       ( const CClientIFP & IFP );
+    void                        RestoreAnimations       ( CAnimBlock & animationBlock );
+    void                        RestoreAllAnimations    ( void );
+    CAnimBlendHierarchySAInterface * getReplacedAnimation ( CAnimBlendHierarchySAInterface * pInternalHierarchyInterface );
 protected:
     // This constructor is for peds managed by a player. These are unknown to the ped manager.
                                 CClientPed                  ( CClientManager* pManager, unsigned long ulModelID, ElementID ID, bool bIsLocalPlayer );
@@ -664,6 +681,9 @@ public:
     bool                        m_bisCurrentAnimationCustom;
     SString                     m_strCustomIFPBlockName;
     SString                     m_strCustomIFPAnimationName;
+
+    // Key: Internal GTA animation, Value: Custom Animation
+    ReplacedAnim_type m_mapOfReplacedAnimations;
 };
 
 #endif

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -92,6 +92,7 @@ public:
     inline CClientEntity*   GetResourceCOLModelRoot ( void )                           { return m_pResourceCOLRoot; };
     inline CClientEntity*   GetResourceDFFRoot ( void )                           { return m_pResourceDFFEntity; };
     inline CClientEntity*   GetResourceTXDRoot ( void )                           { return m_pResourceTXDRoot; };
+    inline CClientEntity*   GetResourceIFPRoot ( void )                           { return m_pResourceIFPRoot; };
 
     // This is to delete all the elements created in this resource that are created locally in this client
     void                    DeleteClientChildren        ( void );

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -27,6 +27,8 @@ public:
     LUA_DECLARE ( EngineRestoreCOL );
     LUA_DECLARE ( EngineReplaceModel );
     LUA_DECLARE ( EngineRestoreModel );
+    LUA_DECLARE ( EngineReplaceAnimation );
+    LUA_DECLARE ( EngineRestoreAnimation );
     LUA_DECLARE ( EngineReplaceMatchingAtomics );
     LUA_DECLARE ( EngineReplaceWheelAtomics );
     LUA_DECLARE ( EnginePositionAtomic );


### PR DESCRIPTION
engineReplaceAnimation and engineRestoreAnimation has been added. They seem to work well. There is a crash that happens when you unload IFP. You can reproduce this, if you unload at least 3 IFP elements at once multiple times but quickly. This crash was not there in commits before 1 week.